### PR TITLE
Minor fix for benchmark_agents.json of CartPole env

### DIFF
--- a/scripts/configs/CartPoleEnv/benchmark_agents.json
+++ b/scripts/configs/CartPoleEnv/benchmark_agents.json
@@ -1,8 +1,8 @@
 {
-    "environments": ["configs/CartpoleEnv/env.json"],
+    "environments": ["configs/CartPoleEnv/env.json"],
     "agents": [
-        "configs/CartpoleEnv/DQNAgent.json",
-        "configs/CartpoleEnv/LinearAgent.json",
-        "configs/CartpoleEnv/MCTSAgent.json"
+        "configs/CartPoleEnv/DQNAgent.json",
+        "configs/CartPoleEnv/LinearAgent.json",
+        "configs/CartPoleEnv/MCTSAgent.json"
     ]
 }


### PR DESCRIPTION
A typo fix for benchmark_agents.json.
Found this minor issue while running benchmarks for this environment.