### PR TITLE
Fix: finalised monitor deprecation in experiments and evaluation scripts

### DIFF
--- a/scripts/experiments.py
+++ b/scripts/experiments.py
@@ -79,7 +79,7 @@ def evaluate(environment_config, agent_config, options):
         evaluation.test()
     else:
         evaluation.close()
-    return os.path.relpath(evaluation.monitor.directory)
+    return os.path.relpath(evaluation.run_directory)
 
 
 def benchmark(options):

--- a/scripts/planners_evaluation.py
+++ b/scripts/planners_evaluation.py
@@ -168,8 +168,8 @@ def evaluate(experiment):
                                 display_agent=False,
                                 display_rewards=False)
         evaluation.test()
-        rewards = evaluation.monitor.stats_recorder.episode_rewards_[0]
-        length = evaluation.monitor.stats_recorder.episode_lengths[0]
+        rewards = evaluation.wrapped_env.episode_returns[0]
+        length = evaluation.wrapped_env.episode_lengths[0]
         total_reward = np.sum(rewards)
         cum_discount = lambda signal: np.sum([gamma**t * signal[t] for t in range(len(signal))])
         return_ = cum_discount(rewards)

--- a/scripts/planners_robust_evaluation.py
+++ b/scripts/planners_robust_evaluation.py
@@ -125,8 +125,8 @@ def evaluate(experiment):
         })
     else:
         evaluation.test()
-        rewards = evaluation.monitor.stats_recorder.episode_rewards_[0]
-        length = evaluation.monitor.stats_recorder.episode_lengths[0]
+        rewards = evaluation.wrapped_env.episode_returns[0]
+        length = evaluation.wrapped_env.episode_lengths[0]
         total_reward = np.sum(rewards)
 
         cum_discount = lambda signal, gamma: np.sum([gamma**t * signal[t] for t in range(len(signal))])


### PR DESCRIPTION
I was about to do some performance improvement modifications for the DQN runner, hoping some stuff could be up-streamable, when discovering that some monitor references were left in place, even after the deprecation, in some quite important places as well (like the experiments script).

I hope I got it right that the monitor stats recorder was replaced by the wrapped environment. If not, pls give me a script I could use to debug and test the problem better. I personally only need to use the `experiments.py` script.

Otherwise, the only other references to the monitor are comments, which I would rather not tackle at this point in time. If you have suggestions, pls mention them, so I can add them in.