### PR TITLE
Fix `AbstractAgent` directory attribute.

### DIFF
--- a/rl_agents/agents/common/abstract.py
+++ b/rl_agents/agents/common/abstract.py
@@ -8,7 +8,7 @@ class AbstractAgent(Configurable, ABC):
     def __init__(self, config=None):
         super(AbstractAgent, self).__init__(config)
         self.writer = None  # Tensorboard writer
-        self.directoy = None  # Run directory
+        self.directory = None  # Run directory
 
     """
         An abstract class specifying the interface of a generic agent.


### PR DESCRIPTION
This is a fairly clear bug.

With that said, I have seen no use of `directory` or `set_directory()` anywhere in the project so it is also possible those attributes should just be removed.